### PR TITLE
Include redirect_uri in POST data

### DIFF
--- a/src/SimpleAuth/Api/WebAuthenticator.cs
+++ b/src/SimpleAuth/Api/WebAuthenticator.cs
@@ -75,7 +75,7 @@ namespace SimpleAuth
 
 		public virtual Task<Dictionary<string, string>> GetTokenPostData(string clientSecret)
 		{
-			return Task.FromResult(new Dictionary<string, string> {
+			var tokenPostData = new Dictionary<string, string> {
 				{
 					"grant_type",
 					"authorization_code"
@@ -89,7 +89,14 @@ namespace SimpleAuth
 					"client_secret",
 					clientSecret
 				},
-			});
+			};
+
+			if (RedirectUrl != null)
+			{
+				tokenPostData["redirect_uri"] = RedirectUrl.ToString();
+			}
+
+			return Task.FromResult(tokenPostData);
 		}
 
 


### PR DESCRIPTION
Hi,

Thanks for this library 👍 

I just spent a bit of time chasing down an issue that amounted to the `redirect_uri` not being included by default in the POST data returned by `WebAuthenticator`. According to [the spec](http://openid.net/specs/openid-connect-core-1_0.html#TokenRequestValidation):

> Ensure that the redirect_uri parameter value is identical to the redirect_uri parameter value that was included in the initial Authorization Request. If the redirect_uri parameter value is not present when there is only one registered redirect_uri value, the Authorization Server MAY return an error (since the Client should have included the parameter) or MAY proceed without an error (since OAuth 2.0 permits the parameter to be omitted in this case)

I was seeing an error. It seems to me that the redirect URI should be included in the token request POST data if provided, so that it matches the one specified in the initial request.