### PR TITLE
Change from RequestServerAuthCode to RequestIdToken

### DIFF
--- a/samples/Sample.Droid/MainActivity.cs
+++ b/samples/Sample.Droid/MainActivity.cs
@@ -36,6 +36,7 @@ namespace Sample.Droid
 				var clientId = "419855213697-uq56vcune334omgqi51ou7jg08i3dnb1.apps.googleusercontent.com"; // Provide with or without the '.apps.googleusercontent.com' suffix
 
 				var google = new SimpleAuth.Providers.GoogleApi("google", clientId) {//, "UwQ8aUXKDpqPzH0gpJnSij3i") {
+                    ServerClientId = "419855213697-uq56vcune334omgqi51ou7jg08i3dnb1.apps.googleusercontent.com",
                     Scopes = new [] { "https://www.googleapis.com/auth/userinfo.profile" }
                 };
 

--- a/src/SimpleAuth.Google.Droid/Google.cs
+++ b/src/SimpleAuth.Google.Droid/Google.cs
@@ -179,7 +179,7 @@ namespace SimpleAuth.Providers
 															.RequestEmail();
 
                     if (serverId != null)
-                        gsoBuilder.RequestServerAuthCode(serverId);
+                        gsoBuilder.RequestIdToken(serverId);
 
                     if (authenticator.Scope != null)
 						foreach (var scope in authenticator.Scope)
@@ -270,7 +270,7 @@ namespace SimpleAuth.Providers
 				try
 				{
 					var gsoBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DefaultSignIn)															
-																.RequestServerAuthCode(serverClientId)
+																.RequestIdToken(serverClientId)
 																.RequestEmail();
 
 					var gso = gsoBuilder.Build();


### PR DESCRIPTION
The GoogleSignInResult doesnt provide the IdToken even if you provide the ServerClientId. To make it work I had to change from RequestServerAuthCode to RequestIdToken.
I know that in the docs :

https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInOptions.Builder#requestServerAuthCode(java.lang.String)

says that it should work, but for me the response didnt provide the IdToken.