### PR TITLE
updated Xamarin.GooglePlayServices.Auth

### DIFF
--- a/src/SimpleAuth.Google.Droid/SimpleAuth.Google.Droid.csproj
+++ b/src/SimpleAuth.Google.Droid/SimpleAuth.Google.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.GooglePlayServices.Auth">
-      <Version>60.1142.1</Version>
+      <Version>71.1600.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />


### PR DESCRIPTION
This was causing a Linking error when updating the Xamarin.GooglePlayServices.Auth in a client app to 71.1600.0